### PR TITLE
Added Lithuania to list of Eurozone countries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,7 @@ eurozone is tuple of country ISO codes::
     Ireland
     Italy
     Latvia
+    Lithuania
     Luxembourg
     Malta
     Netherlands

--- a/ccy/core/country.py
+++ b/ccy/core/country.py
@@ -12,7 +12,7 @@ __all__ = ['country', 'countryccy', 'set_new_country',
 # using ISO 3166-1 alpha-2 country codes
 # see http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 #
-eurozone = tuple(('AT BE CY DE EE ES FI FR GR IE IT LU LV MT '
+eurozone = tuple(('AT BE CY DE EE ES FI FR GR IE IT LU LV LT MT '
                   'NL PT SI SK').split(' '))
 
 

--- a/tests/ccytests.py
+++ b/tests/ccytests.py
@@ -35,7 +35,7 @@ class CcyTest(TestCase):
                           'EU', 'EUR', 'Eurozone')
 
     def test_eurozone(self):
-        self.assertEqual(len(eurozone), 18)
+        self.assertEqual(len(eurozone), 19)
         for c in eurozone:
             self.assertEqual(countryccy(c), 'EUR')
 


### PR DESCRIPTION
Lithuania is a member of Eurozone from 1st of January, 2015.

This PR fixes it :)